### PR TITLE
added doNotSetClientName to the config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,6 +232,8 @@ class RedisJwt {
         this.config.secret = config.secret || 'secret_key';
         this.config.multiple = !config.multiple ? false : true;
 
+        this.config.doNotSetClientName =  !config.doNotSetClientName ? false : true;
+
         // instances
 
         this.d = new Driver(this.config);


### PR DESCRIPTION
Need access to the doNotSetClientName config variable in the redis-fast-driver.